### PR TITLE
Feat/track map views

### DIFF
--- a/apps/web/src/app/app/map/[mapId]/page.tsx
+++ b/apps/web/src/app/app/map/[mapId]/page.tsx
@@ -3,8 +3,10 @@ import { MapStoreProvider } from "@/components/providers/map-state-provider";
 import { convexNextjsOptions, getConvexServerSession } from "@/lib/auth";
 import { api } from "@buzztrip/backend/api";
 import { Id } from "@buzztrip/backend/dataModel";
-import { fetchQuery, preloadQuery } from "convex/nextjs";
+import { mapViewEditSchema, mapViewSchema } from "@buzztrip/backend/zod-schemas";
+import { fetchMutation, fetchQuery, preloadQuery } from "convex/nextjs";
 import { Metadata } from "next";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 
 type Params = Promise<{ mapId: string }>;
@@ -19,6 +21,44 @@ const getMap = async (mapId: string) => {
     options
   );
 };
+
+async function trackMapView(mapId: string, userId?: string) {
+  const headersList = await headers();
+  const ip = headersList.get("x-forwarded-for") || headersList.get("x-real-ip");
+  const userAgent = headersList.get("user-agent");
+
+  // Vercel geo headers
+  const country = headersList.get("x-vercel-ip-country");
+  const region = headersList.get("x-vercel-ip-country-region");
+  const city = headersList.get("x-vercel-ip-city");
+
+  /**Basic function to pase the user agent (UA) string into OS, Browser, and Device */
+  const parseUA = (ua: string) => {
+    const os = /Windows|Mac|Linux|Android|iOS/.exec(ua)?.[0];
+    const browser = /Chrome|Firefox|Safari|Edge/.exec(ua)?.[0];
+    const device = /Mobile|Tablet/.test(ua) ? "Mobile" : "Desktop";
+    return { os, browser, device };
+  };
+
+  const { os, browser, device } = userAgent ? parseUA(userAgent) : {};
+
+  const data = mapViewEditSchema.parse({
+    userId,
+    mapId,
+    ip: ip?.split(",")[0], // First IP if multiple
+    country: country || undefined,
+    region: region || undefined,
+    city: city || undefined,
+    userAgent: userAgent || undefined,
+    os,
+    browser,
+    device,
+  });
+
+  console.log("Adding map view", data);
+
+  await fetchMutation(api.maps.index.trackMapView, data);
+}
 
 export async function generateMetadata({
   params,
@@ -88,7 +128,7 @@ export default async function MapPage({ params }: { params: Params }) {
         },
         options
       ),
-        preloadQuery(
+      preloadQuery(
         api.maps.paths.getPathsForMap,
         {
           mapId: map._id,
@@ -116,6 +156,7 @@ export default async function MapPage({ params }: { params: Params }) {
         },
         options
       ),
+      trackMapView(mapId, session.user._id),
     ]);
 
   return (

--- a/packages/backend/convex/maps/index.ts
+++ b/packages/backend/convex/maps/index.ts
@@ -5,11 +5,12 @@ import type { UserMap } from "../../types";
 import {
   mapsEditSchema,
   mapUserSchema,
+  mapViewEditSchema,
   userMapsSchema,
 } from "../../zod-schemas";
 import { Id } from "../_generated/dataModel";
 import { MutationCtx } from "../_generated/server";
-import { authedMutation, authedQuery } from "../helpers";
+import { authedMutation, authedQuery, zodMutation } from "../helpers";
 import { createCollectionFunction } from "./collections";
 import { createMapUser } from "./mapUsers";
 // Get methods
@@ -34,38 +35,23 @@ export const getMap = authedQuery({
   },
 });
 
-/**
- * We only want to fetch this as a preload before than using all the other queries
- */
-// export const getAllMapData = authedQuery({
-//   args: {
-//     mapId: zid("maps"),
-//   },
-//   handler: async (ctx, args) => {
-//     const markersPromise = ctx.runQuery(api.maps.markers.getMarkersView, {
-//       map_id: args.mapId,
-//     });
-//     const collectionsPromise = ctx.runQuery(
-//       api.maps.collections.getCollectionsForMap,
-//       {
-//         mapId: args.mapId,
-//       }
-//     );
-//     const collectionLinksPromise = ctx.runQuery(
-//       api.maps.collections.getCollectionLinksForMap,
-//       {
-//         mapId: args.mapId,
-//       }
-//     );
-//     const labelsPromise = ctx.runQuery(api.maps.labels.getMapLabels, {
-//       mapId: args.mapId,
-//     });
-//     const mapUsersPromise = ctx.runQuery(api.maps.mapUsers.getMapUsers, {
-//       mapId: args.mapId,
-//     });
+export const trackMapView = zodMutation({
+  args: mapViewEditSchema,
+  handler: async (ctx, args) => {
+    await ctx.db.insert("mapViews", args);
+  },
+});
 
-//   },
-// });
+export const getMapViews = authedQuery({
+  args: {
+    mapId: zid("maps"),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("mapViews")
+      .withIndex("by_map_id", (q) => q.eq("mapId", args.mapId));
+  },
+});
 
 // get all the maps for a user
 export const getUserMaps = authedQuery({

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -7,7 +7,7 @@ import {
   placesReviewSchema,
 } from "../zod-schemas/places-schema";
 
-import { pathsSchema } from "../zod-schemas";
+import { mapViewSchema, pathsSchema } from "../zod-schemas";
 import {
   collection_linksSchema,
   collectionsSchema,
@@ -24,6 +24,9 @@ export default defineSchema({
   maps: defineTable(zodToConvex(mapsSchema)).index("by_visibility", [
     "visibility",
   ]),
+  mapViews: defineTable(zodToConvex(mapViewSchema))
+    .index("by_map_id", ["mapId"])
+    .index("by_user_id", ["userId"]),
   paths: defineTable(zodToConvex(pathsSchema)).index("byMapId", ["mapId"]),
   map_users: defineTable(zodToConvex(mapUserSchema))
     .index("by_map_id", ["map_id"])

--- a/packages/backend/zod-schemas/analytics-schema.ts
+++ b/packages/backend/zod-schemas/analytics-schema.ts
@@ -1,0 +1,19 @@
+import { zid } from "convex-helpers/server/zod";
+import * as z from "zod";
+import { defaultFields, insertSchema } from "./shared-schemas";
+
+export const mapViewSchema = z.object({
+  ...defaultFields,
+  userId: zid("users").optional(),
+  mapId: zid("maps"),
+  ip: z.string().optional(),
+  country: z.string().optional(),
+  region: z.string().optional(),
+  city: z.string().optional(),
+  userAgent: z.string().optional(),
+  os: z.string().optional(),
+  browser: z.string().optional(),
+  device: z.string().optional(),
+});
+
+export const mapViewEditSchema = insertSchema(mapViewSchema);

--- a/packages/backend/zod-schemas/index.ts
+++ b/packages/backend/zod-schemas/index.ts
@@ -9,6 +9,7 @@ export * from "./maps-schema";
 export * from "./places-schema";
 export * from "./shared-schemas";
 export * from "./paths-schema";
+export * from "./analytics-schema";
 
 export const combinedMarkersSchema = markersEditSchema.extend({
   place_id: zid("places").optional(),


### PR DESCRIPTION
This issue implements #98, whenever a user now goes to a page a map view will be logged, this will be a good way to understand how often maps are being used and to access things like last visted date and those sorts of things. 

In the future it would be good to implment like last opened map which could be intergrated into this, a touch more complex though

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Server-side tracking of map views on page load, capturing IP-derived location (country/region/city) and device details (OS, browser, user agent, device).
  - Ability to retrieve view records per map for aggregated insights in the future.
  - Foundation added for indexing view data by map and user to enable efficient lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->